### PR TITLE
update to rust 2018 edition

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,6 +2,7 @@
 name = "input-linux"
 version = "0.5.0"
 authors = ["arcnmx"]
+edition = "2018"
 
 description = "evdev and uinput"
 keywords = ["evdev", "uinput", "linux", "input"]
@@ -16,10 +17,9 @@ input-linux-sys = "^0.7.0"
 nix = "^0.22.0"
 tokio-util = { version = "^0.6.0", default-features = false, features = ["codec"], optional = true }
 bytes = { version = "^1.0.0", optional = true }
-serde = { version = "^1.0.27", optional = true }
-serde_derive = { version = "^1.0.27", optional = true }
+serde = { version = "^1.0.27", features = ["derive"], optional = true }
 
 [features]
 with-tokio = ["tokio-util", "bytes"]
-with-serde = ["serde", "serde_derive"]
+with-serde = ["serde"]
 unstable = []

--- a/examples/mouse-movements.rs
+++ b/examples/mouse-movements.rs
@@ -1,6 +1,3 @@
-extern crate input_linux;
-extern crate nix;
-
 use std::os::unix::fs::OpenOptionsExt;
 use std::{fs::OpenOptions, io, thread, time::Duration};
 

--- a/src/bitmask.rs
+++ b/src/bitmask.rs
@@ -3,7 +3,8 @@
 
 use std::fmt;
 use std::ops::{Deref, DerefMut};
-use enum_iterator::{IterableEnum, EnumIterator};
+use crate::EventKind;
+use crate::enum_iterator::{IterableEnum, EnumIterator};
 
 /// A generic trait that can be used to index by a given type into a set of bits.
 pub trait BitmaskTrait {
@@ -46,7 +47,7 @@ pub type BitmaskVec = Bitmask<Vec<u8>>;
 impl Bitmask<Vec<u8>> {
     /// Reallocate the bitmask to fit all valid code values for the given event
     /// type.
-    pub fn resize(&mut self, kind: ::EventKind) {
+    pub fn resize(&mut self, kind: EventKind) {
         self.data_mut().resize((kind.count_bits().unwrap_or(0x80) + 7) / 8, 0);
     }
 }
@@ -172,7 +173,7 @@ impl<'a, T: BitmaskTrait> Iterator for BitmaskIterator<'a, T> {
 
     fn next(&mut self) -> Option<Self::Item> {
         let mask = &self.mask;
-        self.iter.by_ref().take_while(|i| mask.index_valid(*i)).filter(|i| mask.get(*i)).next()
+        self.iter.by_ref().take_while(|i| mask.index_valid(*i)).find(|i| mask.get(*i))
     }
 }
 

--- a/src/enum_iterator.rs
+++ b/src/enum_iterator.rs
@@ -2,14 +2,14 @@
 
 use std::marker::PhantomData;
 
-/// Allows `EnumIterator` to iterate over an enum type.
+/// Allows [`EnumIterator`] to iterate over an enum type.
 pub trait IterableEnum: Sized {
     /// Given an index into the iterator, return the value and the next index.
     ///
     /// Iterators shall start by calling this with `0`.
     fn iter_next(v: usize) -> Option<(usize, Self)>;
 
-    /// Instantiates an `EnumIterator` for an iterable type.
+    /// Instantiates an [`EnumIterator`] for an iterable type.
     fn iter() -> EnumIterator<Self>;
 }
 

--- a/src/evdev.rs
+++ b/src/evdev.rs
@@ -5,10 +5,13 @@ use std::mem::{MaybeUninit, size_of};
 use std::slice::from_raw_parts_mut;
 use std::os::unix::io::{RawFd, AsRawFd, IntoRawFd, FromRawFd};
 use nix;
-use sys;
-use ::{InputId, EventKind, AbsoluteAxis, AbsoluteInfo};
-use macros::convert_error;
-use bitmask::Bitmask;
+use crate::sys;
+use crate::{
+    AbsoluteAxis, AbsoluteInfo, AutorepeatKind, EventKind, InputId,
+    InputProperty, Key, LedKind, MiscKind, RelativeAxis, SoundKind, SwitchKind
+};
+use crate::macros::convert_error;
+use crate::bitmask::Bitmask;
 
 pub use sys::EV_VERSION;
 
@@ -162,7 +165,7 @@ impl<F: AsRawFd> EvdevHandle<F> {
     }
 
     /// `EVIOCGPROP`
-    pub fn device_properties(&self) -> io::Result<Bitmask<::InputProperty>> {
+    pub fn device_properties(&self) -> io::Result<Bitmask<InputProperty>> {
         let mut bitmask = Bitmask::default();
         self.device_properties_raw(&mut bitmask).map(|_| bitmask)
     }
@@ -194,42 +197,42 @@ impl<F: AsRawFd> EvdevHandle<F> {
         event_bits
     }
 
-    impl_bitmasks! { ::Key, EventKind::Key,
+    impl_bitmasks! { Key, EventKind::Key,
         key_mask, set_key_mask,
         key_bits
     }
 
-    impl_bitmasks! { ::RelativeAxis, EventKind::Relative,
+    impl_bitmasks! { RelativeAxis, EventKind::Relative,
         relative_mask, set_relative_mask,
         relative_bits
     }
 
-    impl_bitmasks! { ::AbsoluteAxis, EventKind::Absolute,
+    impl_bitmasks! { AbsoluteAxis, EventKind::Absolute,
         absolute_mask, set_absolute_mask,
         absolute_bits
     }
 
-    impl_bitmasks! { ::MiscKind, EventKind::Misc,
+    impl_bitmasks! { MiscKind, EventKind::Misc,
         misc_mask, set_misc_mask,
         misc_bits
     }
 
-    impl_bitmasks! { ::SwitchKind, EventKind::Switch,
+    impl_bitmasks! { SwitchKind, EventKind::Switch,
         switch_mask, set_switch_mask,
         switch_bits
     }
 
-    impl_bitmasks! { ::LedKind, EventKind::Led,
+    impl_bitmasks! { LedKind, EventKind::Led,
         led_mask, set_led_mask,
         led_bits
     }
 
-    impl_bitmasks! { ::SoundKind, EventKind::Sound,
+    impl_bitmasks! { SoundKind, EventKind::Sound,
         sound_mask, set_sound_mask,
         sound_bits
     }
 
-    impl_bitmasks! { ::AutorepeatKind, EventKind::Autorepeat,
+    impl_bitmasks! { AutorepeatKind, EventKind::Autorepeat,
         autorepeat_mask, set_autorepeat_mask,
         autorepeat_bits
     }

--- a/src/events.rs
+++ b/src/events.rs
@@ -1,10 +1,12 @@
 use std::convert::TryFrom;
-use sys::input_event;
-use ::{
+use crate::sys::input_event;
+use crate::{
     EventTime, RangeError, KeyState,
     EventKind, SynchronizeKind, Key, RelativeAxis, AbsoluteAxis,
     SwitchKind, MiscKind, LedKind, AutorepeatKind, SoundKind, UInputKind,
 };
+#[cfg(feature = "with-serde")]
+use serde::{Deserialize, Serialize};
 
 #[repr(C)]
 #[derive(Copy, Clone, PartialOrd, Ord, PartialEq, Eq, Hash, Debug)]
@@ -159,7 +161,7 @@ pub struct InputEvent {
     /// The code of the event.
     ///
     /// The meaning of this code depends on the `kind` of event. Using the typed
-    /// events via `Event` and `EventRef` is recommended.
+    /// events via [`Event`] and [`EventRef`] is recommended.
     pub code: u16,
     /// The value of the event.
     ///
@@ -369,7 +371,7 @@ impl AsRef<InputEvent> for InputEvent {
 }
 
 impl InputEvent {
-    /// Reinterprets a raw `input_event`.
+    /// Reinterprets a raw [`input_event`].
     pub fn from_raw(event: &input_event) -> Result<&Self, RangeError> {
         EventKind::from_type(event.type_).map(|_| {
             let raw = event as *const _ as *const _;
@@ -377,7 +379,7 @@ impl InputEvent {
         })
     }
 
-    /// Reinterprets a raw `input_event` into a mutable reference.
+    /// Reinterprets a raw [`input_event`] into a mutable reference.
     pub fn from_raw_mut(event: &mut input_event) -> Result<&mut Self, RangeError> {
         EventKind::from_type(event.type_).map(|_| {
             let raw = event as *mut _ as *mut _;
@@ -385,13 +387,13 @@ impl InputEvent {
         })
     }
 
-    /// Reinterprets the event as a raw `input_event`.
+    /// Reinterprets the event as a raw [`input_event`].
     pub fn as_raw(&self) -> &input_event {
         let raw = self as *const _ as *const _;
         unsafe { &*raw }
     }
 
-    /// Reinterprets the event as a mutable raw `input_event`.
+    /// Reinterprets the event as a mutable raw [`input_event`].
     pub unsafe fn as_raw_mut(&mut self) -> &mut input_event {
         let raw = self as *mut _ as *mut _;
         &mut *raw
@@ -435,7 +437,7 @@ macro_rules! input_event_enum {
         }
 
         impl Event {
-            /// Converts a generic `InputEvent` to a typed event.
+            /// Converts a generic [`InputEvent`] to a typed event.
             pub fn new(event: InputEvent) -> Result<Self, RangeError> {
                 match event.kind {
                 $(
@@ -447,7 +449,7 @@ macro_rules! input_event_enum {
         }
 
         impl<'a> EventRef<'a> {
-            /// Wraps the generic `InputEvent` into an event.
+            /// Wraps the generic [`InputEvent`] into an event.
             pub fn new(event: &'a InputEvent) -> Result<Self, RangeError> {
                 match event.kind {
                 $(
@@ -459,7 +461,7 @@ macro_rules! input_event_enum {
         }
 
         impl<'a> EventMut<'a> {
-            /// Wraps the generic `InputEvent` into a mutable event.
+            /// Wraps the generic [`InputEvent`] into a mutable event.
             pub fn new(event: &'a mut InputEvent) -> Result<Self, RangeError> {
                 match event.kind {
                 $(

--- a/src/keys.rs
+++ b/src/keys.rs
@@ -1,4 +1,6 @@
-use sys;
+use crate::sys;
+#[cfg(feature = "with-serde")]
+use serde::{Deserialize, Serialize};
 
 /// Keys and Buttons
 ///

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,49 +1,45 @@
 #![deny(missing_docs)]
-#![doc(html_root_url = "https://docs.rs/input-linux/0.4.0/")]
+#![doc(html_root_url = "https://docs.rs/input-linux/0.5.0/")]
 
 //! Userspace bindings to the Linux evdev and uinput subsystems.
 //!
-//! Start by looking at the `EvdevHandle` and `UInputHandle` types.
+//! Start by looking at the [`EvdevHandle`] and [`UInputHandle`] types.
 
-pub extern crate input_linux_sys as sys;
-extern crate nix;
+pub use input_linux_sys as sys;
 #[cfg(feature = "with-serde")]
-extern crate serde;
-#[cfg(feature = "with-serde")]
-#[macro_use]
-extern crate serde_derive;
+use serde::{Deserialize, Serialize, };
 
 #[macro_use]
 mod macros;
 
 mod kinds;
-pub use kinds::*;
+pub use crate::kinds::*;
 
 mod time;
-pub use time::EventTime;
+pub use crate::time::EventTime;
 
 mod events;
-pub use events::*;
+pub use crate::events::*;
 
 mod keys;
-pub use keys::Key;
+pub use crate::keys::Key;
 
 pub mod evdev;
-pub use evdev::EvdevHandle;
+pub use crate::evdev::EvdevHandle;
 
 pub mod uinput;
-pub use uinput::UInputHandle;
+pub use crate::uinput::UInputHandle;
 
 pub mod enum_iterator;
 
 pub mod bitmask;
-pub use bitmask::Bitmask;
+pub use crate::bitmask::Bitmask;
 
 #[cfg(feature = "with-tokio")]
 mod tokio;
 
 #[cfg(feature = "with-tokio")]
-pub use tokio::EventCodec;
+pub use crate::tokio::EventCodec;
 
 #[repr(C)]
 #[derive(Copy, Clone, Default, PartialOrd, Ord, PartialEq, Eq, Hash, Debug)]
@@ -76,13 +72,13 @@ impl<'a> From<&'a InputId> for &'a sys::input_id {
 
 impl From<sys::input_id> for InputId {
     fn from(id: sys::input_id) -> Self {
-        <&InputId>::from(&id).clone()
+        *<&InputId>::from(&id)
     }
 }
 
 impl From<InputId> for sys::input_id {
     fn from(id: InputId) -> Self {
-        <&sys::input_id>::from(&id).clone()
+        *<&sys::input_id>::from(&id)
     }
 }
 
@@ -152,12 +148,12 @@ impl<'a> From<&'a AbsoluteInfo> for &'a sys::input_absinfo {
 
 impl From<sys::input_absinfo> for AbsoluteInfo {
     fn from(info: sys::input_absinfo) -> Self {
-        <&AbsoluteInfo>::from(&info).clone()
+        *<&AbsoluteInfo>::from(&info)
     }
 }
 
 impl From<AbsoluteInfo> for sys::input_absinfo {
     fn from(info: AbsoluteInfo) -> Self {
-        <&sys::input_absinfo>::from(&info).clone()
+        *<&sys::input_absinfo>::from(&info)
     }
 }

--- a/src/macros.rs
+++ b/src/macros.rs
@@ -1,5 +1,5 @@
 use std::io;
-use sys;
+use crate::sys;
 
 pub(crate) const STRING_BUFFER_LENGTH: usize = 0x200;
 
@@ -9,30 +9,30 @@ pub(crate) fn convert_error(e: sys::Error) -> io::Error {
 
 macro_rules! impl_iterable {
     (@impliter $name: ident($start:expr, $count:expr)) => {
-        impl ::bitmask::BitmaskTrait for $name {
+        impl crate::bitmask::BitmaskTrait for $name {
             type Array = [u8; (Self::COUNT + 7) / 8];
             type Index = $name;
             const ZERO: Self::Array = [0u8; (Self::COUNT + 7) / 8];
 
-            fn array_default() -> Self::Array { unsafe { ::std::mem::zeroed() } }
+            fn array_default() -> Self::Array { unsafe {std::mem::zeroed() } }
             fn array_slice(array: &Self::Array) -> &[u8] { array }
             fn array_slice_mut(array: &mut Self::Array) -> &mut [u8] { array }
             fn index(index: Self::Index) -> usize { index as usize }
         }
 
-        impl ::enum_iterator::IterableEnum for $name {
+        impl crate::enum_iterator::IterableEnum for $name {
             fn iter_next(v: usize) -> Option<(usize, Self)> {
                 if v < Self::COUNT {
                     unsafe {
-                        Some((v + 1, ::std::mem::transmute(v as u16)))
+                        Some((v + 1, std::mem::transmute(v as u16)))
                     }
                 } else {
                     None
                 }
             }
 
-            fn iter() -> ::enum_iterator::EnumIterator<Self> {
-                ::enum_iterator::EnumIterator::new($start)
+            fn iter() -> crate::enum_iterator::EnumIterator<Self> {
+                crate::enum_iterator::EnumIterator::new($start)
             }
         }
 
@@ -41,12 +41,12 @@ macro_rules! impl_iterable {
             pub const COUNT: usize = $count as usize;
 
             /// An iterator over all values of the enum.
-            pub fn iter() -> ::enum_iterator::EnumIterator<Self> {
-                ::enum_iterator::IterableEnum::iter()
+            pub fn iter() -> crate::enum_iterator::EnumIterator<Self> {
+                crate::enum_iterator::IterableEnum::iter()
             }
 
             /// A bitmask that can contain all values of the enum.
-            pub fn bitmask() -> ::bitmask::Bitmask<Self> {
+            pub fn bitmask() -> crate::bitmask::Bitmask<Self> {
                 Default::default()
             }
         }
@@ -60,19 +60,19 @@ macro_rules! impl_iterable {
     (@implcode $name: ident($start:expr, $count:expr)) => {
         impl $name {
             /// Instantiates the enum from a raw code value.
-            pub fn from_code(code: u16) -> Result<Self, ::kinds::RangeError> {
+            pub fn from_code(code: u16) -> Result<Self, crate::kinds::RangeError> {
                 use std::mem;
 
                 if code < Self::COUNT as u16 {
                     Ok(unsafe { mem::transmute(code) })
                 } else {
-                    Err(::kinds::RangeError)
+                    Err(crate::kinds::RangeError)
                 }
             }
         }
 
         impl std::convert::TryFrom<u16> for $name {
-            type Error = ::kinds::RangeError;
+            type Error = crate::kinds::RangeError;
 
             fn try_from(code: u16) -> Result<Self, Self::Error> {
                 Self::from_code(code)
@@ -93,10 +93,10 @@ macro_rules! ioctl_impl {
         $(#[$attr])*
         pub fn $f(&self) -> io::Result<$ret> {
             unsafe {
-                let mut v = ::std::mem::MaybeUninit::uninit();
+                let mut v = std::mem::MaybeUninit::uninit();
                 sys::$ev(self.fd(), &mut *v.as_mut_ptr())
                     .map(|_| v.assume_init().into())
-                    .map_err(::macros::convert_error)
+                    .map_err(crate::macros::convert_error)
             }
         }
     };
@@ -106,7 +106,7 @@ macro_rules! ioctl_impl {
             unsafe {
                 sys::$ev(self.fd())
                     .map(drop)
-                    .map_err(::macros::convert_error)
+                    .map_err(crate::macros::convert_error)
             }
         }
     };
@@ -116,7 +116,7 @@ macro_rules! ioctl_impl {
             unsafe {
                 sys::$ev(self.fd(), &mut *(buffer as *mut [$ty] as *mut [_]))
                     .map(|len| len as _)
-                    .map_err(::macros::convert_error)
+                    .map_err(crate::macros::convert_error)
             }
         }
     };
@@ -128,7 +128,7 @@ macro_rules! ioctl_impl {
 
         $(#[$attr])*
         pub fn $f(&self) -> io::Result<Vec<u8>> {
-            let mut buf = vec![0; ::macros::STRING_BUFFER_LENGTH];
+            let mut buf = vec![0; crate::macros::STRING_BUFFER_LENGTH];
             self.$fbuf(&mut buf[..]).map(move |len| {
                 buf.truncate(len as _);
                 buf
@@ -141,7 +141,7 @@ macro_rules! ioctl_impl {
             unsafe {
                 sys::$ev(self.fd(), value.as_ptr())
                     .map(drop)
-                    .map_err(::macros::convert_error)
+                    .map_err(crate::macros::convert_error)
             }
         }
     };
@@ -151,7 +151,7 @@ macro_rules! ioctl_impl {
             unsafe {
                 sys::$ev(self.fd(), value as _)
                     .map(drop)
-                    .map_err(::macros::convert_error)
+                    .map_err(crate::macros::convert_error)
             }
         }
     };
@@ -165,19 +165,19 @@ macro_rules! ioctl_impl {
 macro_rules! impl_bitmasks {
     { $kind:path, $event: expr, $name_mask:ident, $name_mask_set:ident, $name_bits:ident } => {
         /// `EVIOCGMASK`
-        pub fn $name_mask(&self) -> io::Result<::bitmask::Bitmask<$kind>> {
-            let mut bitmask = ::bitmask::Bitmask::default();
+        pub fn $name_mask(&self) -> io::Result<crate::bitmask::Bitmask<$kind>> {
+            let mut bitmask = crate::bitmask::Bitmask::default();
             self.event_mask_raw($event, &mut bitmask).map(|_| bitmask)
         }
 
         /// `EVIOCSMASK`
-        pub fn $name_mask_set(&self, bitmask: &::bitmask::Bitmask<$kind>) -> io::Result<()> {
+        pub fn $name_mask_set(&self, bitmask: &crate::bitmask::Bitmask<$kind>) -> io::Result<()> {
             self.set_event_mask_raw($event, bitmask)
         }
 
         /// `EVIOCGBIT`
-        pub fn $name_bits(&self) -> io::Result<::bitmask::Bitmask<$kind>> {
-            let mut bitmask = ::bitmask::Bitmask::default();
+        pub fn $name_bits(&self) -> io::Result<crate::bitmask::Bitmask<$kind>> {
+            let mut bitmask = crate::bitmask::Bitmask::default();
             self.event_bits_raw($event, &mut bitmask).map(|_| bitmask)
         }
     };

--- a/src/time.rs
+++ b/src/time.rs
@@ -1,8 +1,10 @@
 use std::{fmt, cmp};
 use std::hash::{Hash, Hasher};
 use std::ops::{Deref, DerefMut};
-use sys::timeval;
+use crate::sys::timeval;
 use nix::libc::{time_t, suseconds_t};
+#[cfg(feature = "with-serde")]
+use serde::{Serialize, Deserialize};
 
 /// An event timestamp.
 #[repr(C)]
@@ -31,7 +33,7 @@ impl EventTime {
         })
     }
 
-    /// Create a timestamp given a libc `timeval`.
+    /// Create a timestamp given a libc [`timeval`].
     pub const fn from_timeval(time: timeval) -> Self {
         EventTime(time)
     }
@@ -59,7 +61,7 @@ impl EventTime {
         (self.0).tv_usec = value as suseconds_t
     }
 
-    /// The inner `libc` type.
+    /// The inner `libc` [`timeval`].
     pub const fn into_inner(self) -> timeval {
         self.0
     }
@@ -157,4 +159,4 @@ impl Ord for EventTime {
     }
 }
 
-impl Eq for EventTime { }
+impl Eq for EventTime {}

--- a/src/tokio.rs
+++ b/src/tokio.rs
@@ -4,10 +4,10 @@ extern crate tokio_util;
 extern crate bytes;
 
 use std::{io, mem, ptr};
-use sys::input_event;
+use crate::sys::input_event;
 use self::tokio_util::codec::{Decoder, Encoder};
 use self::bytes::{BytesMut, BufMut};
-use InputEvent;
+use crate::InputEvent;
 
 pub struct EventCodec {
     _dummy: (),

--- a/src/uinput.rs
+++ b/src/uinput.rs
@@ -9,13 +9,12 @@ use std::mem::{MaybeUninit, size_of};
 use std::path::{Path, PathBuf};
 use std::slice::{from_raw_parts, from_raw_parts_mut};
 use std::ffi::{OsStr, OsString, CStr};
-use sys;
+use crate::sys;
 use nix;
-use ::{InputId, AbsoluteInfoSetup, kinds};
-use macros::convert_error;
+use crate::{Key, InputId, AbsoluteInfoSetup, kinds};
+use crate::macros::{convert_error};
 
-pub use sys::UINPUT_VERSION;
-pub use sys::UINPUT_MAX_NAME_SIZE;
+pub use crate::sys::{UINPUT_MAX_NAME_SIZE, UINPUT_VERSION};
 
 /// A handle to a uinput allowing the use of ioctls
 pub struct UInputHandle<F>(F);
@@ -27,7 +26,7 @@ fn copy_name(dest: &mut [c_char; UINPUT_MAX_NAME_SIZE as usize], name: &[u8]) ->
         unsafe {
             ptr::copy_nonoverlapping(name.as_ptr() as *const _, dest.as_mut_ptr() as *mut _, name.len());
         }
-        dest[name.len()] = 0 as _;
+        dest[name.len()] = 0;
 
         Ok(())
     }
@@ -201,7 +200,7 @@ impl<F: AsRawFd> UInputHandle<F> {
         }
         {
             /// `UI_SET_KEYBIT`
-            @set set_keybit(::Key) = ui_set_keybit
+            @set set_keybit(Key) = ui_set_keybit
         }
         {
             /// `UI_SET_RELBIT`


### PR DESCRIPTION
mostly change `::` to `crate::`
add intra-doc links
fix some clippy lints
fixes #10 