### PR TITLE
Fix timeval on 32-bit systems - serde feature

### DIFF
--- a/src/time.rs
+++ b/src/time.rs
@@ -20,8 +20,8 @@ timeval
 #[serde(remote = "timeval")]
 #[allow(dead_code)]
 struct TimevalDef {
-    tv_sec: i64,
-    tv_usec: i64,
+    tv_sec: time_t,
+    tv_usec: suseconds_t,
 }
 
 impl EventTime {


### PR DESCRIPTION
Hello. PR #3 forgot to fix the `TimevalDef` auxiliary struct. As a result, the library still fails to build on systems with 32-bit times when the `serde` feature is activated. This PR fixes this.